### PR TITLE
feat: auto-expand collapsed nodes when children are dropped

### DIFF
--- a/src/controller/drag-drop-manager.js
+++ b/src/controller/drag-drop-manager.js
@@ -542,6 +542,12 @@ class DragDropManager {
     console.log(`Dragged node: "${draggedNode.text}" (level ${draggedNode.level})`);
     console.log(`Target node: "${targetNode.text}" (level ${targetNode.level})`);
     
+    // If the target node is collapsed, expand it so the user can see the dropped child
+    if (targetNode.collapsed) {
+      console.log(`Target node "${targetNode.text}" is collapsed - expanding to show dropped child`);
+      targetNode.collapsed = false;
+    }
+    
     // Remove from current parent
     const currentParent = this.model.findParentNode(draggedNode);
     console.log(`Current parent: ${currentParent ? `"${currentParent.text}"` : 'null'}`);


### PR DESCRIPTION
Automatically expand collapsed nodes when a new child is dropped onto them via drag-and-drop. This provides immediate visual feedback to users, allowing them to see the result of their drop operation without needing to manually expand the target node.

- Enhanced dropAsChild method to check for collapsed target nodes
- Sets collapsed = false before adding the dropped child
- Improves user experience by showing dropped children immediately
- Maintains intuitive drag-and-drop behavior

🤖 Generated with [Claude Code](https://claude.ai/code)