### PR TITLE
feat: Add bidirectional markdown sync with autosave for mindmap edits

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,10 @@
             <div class="editor-container">
                 <label for="markdown-input">Paste Your MindMap Markdown:</label>
                 <textarea id="markdown-input" placeholder="# Root Topic&#10;## Subtopic 1&#10;### Detail 1.1&#10;## Subtopic 2"></textarea>
+                <div class="form-group checkbox-group">
+                    <input type="checkbox" id="autosave-markdown" name="autosave-markdown">
+                    <label for="autosave-markdown">Auto-save mindmap edits back to markdown</label>
+                </div>
                 <div id="status-message"></div>
                 <button id="generate-btn">Generate MindMap</button>
             </div>

--- a/index.html
+++ b/index.html
@@ -148,6 +148,7 @@
                 <select id="export-format">
                     <option value="svg" selected>SVG Vector</option>
                     <option value="png">PNG Image</option>
+                    <option value="markdown">Markdown</option>
                 </select>
                 <button id="export-btn">Export</button>
             </div>

--- a/src/app.js
+++ b/src/app.js
@@ -657,17 +657,37 @@ class MindmapApp {
    * Handle export button click
    */
   handleExport() {
-    if (!this.exportFormat || !this.container) return;
+    if (!this.exportFormat) return;
 
     const format = this.exportFormat.value;
-    const svgContent = this.container.dataset.svgContent;
 
+    // For markdown export, we don't need SVG content, just the model
+    if (format === 'markdown') {
+      if (!this.model.getRoot()) {
+        console.warn('No mindmap model to export. Generate one first.');
+        return;
+      }
+      
+      // Extract filename from root node text
+      const rootNode = this.model.getRoot();
+      const fileName = rootNode && rootNode.text ?
+        rootNode.text.replace(/[^\w\s]/g, '').replace(/\s+/g, '_').toLowerCase() :
+        'mindmap';
+
+      this.controller.exportToMarkdown(fileName + '.md');
+      return;
+    }
+
+    // For SVG/PNG exports, we need the container and SVG content
+    if (!this.container) return;
+    
+    const svgContent = this.container.dataset.svgContent;
     if (!svgContent) {
       console.warn('No mindmap to export. Generate one first.');
       return;
     }
 
-    // Extract filename from root node text
+    // Extract filename from root node text for SVG/PNG
     const rootTextMatch = svgContent.match(/<text[^>]*>([^<]+)<\/text>/);
     const fileName = rootTextMatch ?
       rootTextMatch[1].replace(/[^\w\s]/g, '').replace(/\s+/g, '_').toLowerCase() :

--- a/src/app.js
+++ b/src/app.js
@@ -73,6 +73,7 @@ class MindmapApp {
     this.dropZonesCheckbox = document.getElementById('enable-drop-zones');
     this.outlineEdgeAlignmentSelect = document.getElementById('outline-edge-alignment');
     this.applySettingsBtn = document.getElementById('apply-settings-btn');
+    this.autosaveMarkdownCheckbox = document.getElementById('autosave-markdown');
     
     // YAML editor elements
     this.styleYamlEditor = document.getElementById('style-yaml-editor');
@@ -841,6 +842,60 @@ class MindmapApp {
     console.groupEnd();
     
     return this; // Allow method chaining
+  }
+
+  /**
+   * Auto-save mindmap changes back to markdown editor if enabled
+   */
+  autoSaveToMarkdown() {
+    if (!this.autosaveMarkdownCheckbox || !this.autosaveMarkdownCheckbox.checked) {
+      return; // Autosave is disabled
+    }
+
+    if (!this.model.getRoot() || !this.markdownInput) {
+      return; // No model or markdown input available
+    }
+
+    try {
+      // Convert current mindmap structure back to markdown
+      const updatedMarkdown = this.model.toMarkdown();
+      const currentMarkdown = this.markdownInput.value.trim();
+      
+      // Only update if there's a meaningful difference (ignoring whitespace differences)
+      if (updatedMarkdown && updatedMarkdown.trim() !== currentMarkdown) {
+        console.log('Auto-saving mindmap changes to markdown editor');
+        console.log('Previous length:', currentMarkdown.length, 'New length:', updatedMarkdown.length);
+        
+        this.markdownInput.value = updatedMarkdown;
+        
+        // Show brief status message
+        this.showStatusMessage('Markdown auto-saved', 'success');
+      }
+    } catch (error) {
+      console.error('Error during auto-save to markdown:', error);
+      this.showStatusMessage('Auto-save failed', 'error');
+    }
+  }
+
+  /**
+   * Show a status message to the user
+   * @param {string} message - The message to show
+   * @param {string} type - The type of message ('success', 'error', 'info')
+   */
+  showStatusMessage(message, type = 'info') {
+    const statusElement = document.getElementById('status-message');
+    if (!statusElement) return;
+
+    statusElement.textContent = message;
+    statusElement.className = `status-${type}`;
+    statusElement.style.display = 'block';
+
+    // Hide message after 2 seconds
+    setTimeout(() => {
+      statusElement.style.display = 'none';
+      statusElement.textContent = '';
+      statusElement.className = '';
+    }, 2000);
   }
 
   /**

--- a/src/controller/drag-drop-manager.js
+++ b/src/controller/drag-drop-manager.js
@@ -516,6 +516,13 @@ class DragDropManager {
     // Re-render the mindmap without re-parsing markdown
     this.controller.rerenderMindmap();
     
+    // Trigger autosave if enabled (through global app reference)
+    if (typeof window !== 'undefined' && window.mindmapApp && window.mindmapApp.autoSaveToMarkdown) {
+      setTimeout(() => {
+        window.mindmapApp.autoSaveToMarkdown();
+      }, 100); // Small delay to ensure re-render is complete
+    }
+    
     console.log('=== END PERFORM DROP DEBUG ===');
   }
   

--- a/src/controller/mindmap-controller.js
+++ b/src/controller/mindmap-controller.js
@@ -712,6 +712,32 @@ logPropertyInheritanceChain(node, property) {
     const url = URL.createObjectURL(svgBlob);
     img.src = url;
   }
+
+  /**
+   * Export the current mindmap as a Markdown file
+   * @param {string} filename - The filename for the exported markdown file
+   */
+  exportToMarkdown(filename) {
+    const markdownContent = this.model.toMarkdown();
+    
+    if (!markdownContent) {
+      console.warn('No mindmap content available for markdown export');
+      return;
+    }
+
+    // Create blob and trigger download
+    const blob = new Blob([markdownContent], { type: 'text/markdown' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename || 'mindmap.md';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+
+    console.log('Markdown exported successfully');
+  }
 }
 
 // For backward compatibility

--- a/src/model/mindmap-model.js
+++ b/src/model/mindmap-model.js
@@ -528,6 +528,62 @@ class MindmapModel {
 
     return null;
   }
+
+  /**
+   * Convert the node structure back to markdown
+   * @param {MindmapNode} node - The root node to convert (optional, defaults to this.rootNode)
+   * @return {string} The markdown representation of the node structure
+   */
+  toMarkdown(node = null) {
+    const startNode = node || this.rootNode;
+    if (!startNode) {
+      return '';
+    }
+
+    const lines = [];
+    this._nodeToMarkdown(startNode, lines, 0);
+    return lines.join('\n');
+  }
+
+  /**
+   * Recursively convert a node and its children to markdown lines
+   * @private
+   * @param {MindmapNode} node - The node to convert
+   * @param {Array<string>} lines - Array to collect markdown lines
+   * @param {number} depth - Current depth for indentation (0-based)
+   */
+  _nodeToMarkdown(node, lines, depth) {
+    if (!node) return;
+
+    if (node.level === 1 && depth === 0) {
+      // Root node becomes a top-level heading
+      lines.push(`# ${node.text}`);
+    } else if (node.level >= 1 && node.level <= 6) {
+      // Convert levels to headings
+      const headingMarker = '#'.repeat(node.level);
+      lines.push(`${headingMarker} ${node.text}`);
+    } else {
+      // For deeper levels or list items, use bullet points with proper indentation
+      const indent = '  '.repeat(depth);
+      lines.push(`${indent}- ${node.text}`);
+    }
+
+    // Process children
+    if (node.children && node.children.length > 0) {
+      for (const child of node.children) {
+        if (node.level >= 1 && node.level <= 6 && child.level > 6) {
+          // If parent is a heading but child would be deeper than h6, use list format
+          this._nodeToMarkdown(child, lines, 0);
+        } else if (node.level >= 1 && node.level <= 6) {
+          // Both parent and child are heading levels
+          this._nodeToMarkdown(child, lines, 0);
+        } else {
+          // Parent is a list item, child should be indented list item
+          this._nodeToMarkdown(child, lines, depth + 1);
+        }
+      }
+    }
+  }
 }
 
 // Make the mindmap model and parsing function available globally

--- a/style.css
+++ b/style.css
@@ -533,3 +533,32 @@ body.resizing .preview {
 .yaml-load-btn:hover {
     background-color: #1976d2;
 }
+
+/* Status messages */
+#status-message {
+    display: none;
+    padding: 8px 12px;
+    border-radius: 4px;
+    font-size: 12px;
+    font-weight: 500;
+    margin: 8px 0;
+    transition: opacity 0.3s ease;
+}
+
+.status-success {
+    background-color: #d4edda;
+    color: #155724;
+    border: 1px solid #c3e6cb;
+}
+
+.status-error {
+    background-color: #f8d7da;
+    color: #721c24;
+    border: 1px solid #f5c6cb;
+}
+
+.status-info {
+    background-color: #cce7ff;
+    color: #004085;
+    border: 1px solid #99d6ff;
+}

--- a/test-autosave.js
+++ b/test-autosave.js
@@ -1,0 +1,126 @@
+// Test script for autosave functionality
+// This can be run in browser console to test the autosave feature
+
+function testAutosaveFeature() {
+  console.log('🧪 Testing autosave functionality...');
+  
+  if (!window.mindmapApp || !window.mindmapModel) {
+    console.error('❌ MindmapApp or MindmapModel not available');
+    return;
+  }
+
+  const app = window.mindmapApp;
+  const checkbox = app.autosaveMarkdownCheckbox;
+  const markdownInput = app.markdownInput;
+  
+  if (!checkbox || !markdownInput) {
+    console.error('❌ Autosave checkbox or markdown input not found');
+    return;
+  }
+
+  console.log('✅ Found autosave elements');
+  
+  // Test 1: Check if checkbox exists and can be toggled
+  console.log('Test 1: Checkbox functionality');
+  const originalChecked = checkbox.checked;
+  checkbox.checked = true;
+  console.log('Checkbox set to:', checkbox.checked ? 'enabled' : 'disabled');
+  
+  // Test 2: Test the autoSaveToMarkdown method directly
+  console.log('Test 2: Testing autoSaveToMarkdown method');
+  const originalMarkdown = markdownInput.value;
+  console.log('Original markdown length:', originalMarkdown.length);
+  
+  // Generate a mindmap first to have something to convert
+  app.handleGenerate().then(() => {
+    console.log('Mindmap generated successfully');
+    
+    // Test the autosave method
+    app.autoSaveToMarkdown();
+    
+    setTimeout(() => {
+      const newMarkdown = markdownInput.value;
+      console.log('New markdown length:', newMarkdown.length);
+      console.log('Markdown changed:', originalMarkdown !== newMarkdown ? '✅ Yes' : '❌ No');
+      
+      if (originalMarkdown !== newMarkdown) {
+        console.log('📝 Updated markdown preview:');
+        console.log(newMarkdown.substring(0, 200) + (newMarkdown.length > 200 ? '...' : ''));
+      }
+      
+      console.log('🎉 Autosave test completed!');
+    }, 500);
+  }).catch(error => {
+    console.error('❌ Error generating mindmap:', error);
+  });
+  
+  // Reset checkbox to original state
+  checkbox.checked = originalChecked;
+}
+
+// Test drag-drop autosave integration
+function testDragDropAutosave() {
+  console.log('🧪 Testing drag-drop autosave integration...');
+  
+  if (!window.mindmapApp) {
+    console.error('❌ MindmapApp not available');
+    return;
+  }
+
+  const app = window.mindmapApp;
+  const checkbox = app.autosaveMarkdownCheckbox;
+  
+  if (!checkbox) {
+    console.error('❌ Autosave checkbox not found');
+    return;
+  }
+
+  // Enable autosave
+  checkbox.checked = true;
+  console.log('✅ Autosave enabled for drag-drop test');
+  console.log('💡 Now try dragging a node in the mindmap to test autosave...');
+  console.log('💡 Check the markdown editor - it should update automatically after drag operations');
+  
+  // Set up a listener to detect when autosave happens
+  const originalMethod = app.autoSaveToMarkdown;
+  let callCount = 0;
+  
+  app.autoSaveToMarkdown = function() {
+    callCount++;
+    console.log(`🔄 Autosave triggered (call #${callCount})`);
+    const result = originalMethod.call(this);
+    console.log('✅ Autosave completed');
+    return result;
+  };
+  
+  // Restore after 30 seconds
+  setTimeout(() => {
+    app.autoSaveToMarkdown = originalMethod;
+    console.log(`📊 Autosave test completed. Total calls: ${callCount}`);
+  }, 30000);
+}
+
+// Comprehensive test suite
+function runAutosaveTestSuite() {
+  console.log('🚀 Running comprehensive autosave test suite...');
+  
+  // Test the basic functionality first
+  testAutosaveFeature();
+  
+  // Wait a bit, then test drag-drop integration
+  setTimeout(() => {
+    testDragDropAutosave();
+  }, 2000);
+}
+
+// Make functions available globally
+if (typeof window !== 'undefined') {
+  window.testAutosaveFeature = testAutosaveFeature;
+  window.testDragDropAutosave = testDragDropAutosave;
+  window.runAutosaveTestSuite = runAutosaveTestSuite;
+  
+  console.log('🧪 Autosave test functions available:');
+  console.log('- testAutosaveFeature()');
+  console.log('- testDragDropAutosave()'); 
+  console.log('- runAutosaveTestSuite()');
+}

--- a/test-markdown-conversion.js
+++ b/test-markdown-conversion.js
@@ -1,0 +1,69 @@
+// Test script for markdown conversion
+// This can be run in browser console to test the backward conversion
+
+function testMarkdownConversion() {
+  console.log('Testing backward markdown conversion...');
+  
+  // Test markdown input
+  const testMarkdown = `# Project Planning
+## Research
+- competitive landscape
+  - existing mindmap apps
+    - open source
+      - Xmind
+        - pros
+          - open source
+          - feature rich
+        - cons
+          - file format issues
+    - proprietary
+- market analysis
+## Design
+### UI/UX Design
+### System Architecture
+#### Class Diagram
+- browser based
+- client-side only
+## Development
+### Frontend
+- markdown parsing
+- layout algorithms
+- styling
+### Testing
+- unit tests
+- integration tests`;
+
+  // Test the conversion
+  if (typeof window !== 'undefined' && window.mindmapModel) {
+    window.mindmapModel.parseFromMarkdown(testMarkdown).then(rootNode => {
+      if (rootNode) {
+        console.log('✅ Parsed markdown successfully');
+        console.log('Root node:', rootNode);
+        
+        // Test backward conversion
+        const convertedMarkdown = window.mindmapModel.toMarkdown();
+        console.log('✅ Converted back to markdown:');
+        console.log(convertedMarkdown);
+        
+        // Compare structure
+        console.log('\n=== COMPARISON ===');
+        console.log('Original lines:', testMarkdown.split('\n').length);
+        console.log('Converted lines:', convertedMarkdown.split('\n').length);
+        
+        return convertedMarkdown;
+      } else {
+        console.error('❌ Failed to parse markdown');
+      }
+    }).catch(error => {
+      console.error('❌ Error during parsing:', error);
+    });
+  } else {
+    console.error('❌ MindmapModel not available in window');
+  }
+}
+
+// Make available globally
+if (typeof window !== 'undefined') {
+  window.testMarkdownConversion = testMarkdownConversion;
+  console.log('Test function available as window.testMarkdownConversion()');
+}


### PR DESCRIPTION
Implement bidirectional synchronization between the visual mindmap and markdown editor, allowing users to:
  - Export edited mindmap structures back to markdown format
  - Automatically sync visual changes to the markdown editor with an optional autosave feature
  - Maintain consistency between visual and text representations