### PR TITLE
feat: add node selection with keyboard navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,12 +135,16 @@
                 <div class="help-tooltip-content">
                     <h3>Navigation Controls</h3>
                     <ul>
-                       <li><strong>Scroll:</strong> Mouse wheel to scroll vertically or Arrow keys</li>
+                       <li><strong>Select Node:</strong> Click on any node</li>
+                       <li><strong>Navigate Selection:</strong> Arrow keys to move between nodes</li>
+                       <li><strong>Scroll:</strong> Mouse wheel to scroll vertically</li>
                        <li><strong>Horizontal Scroll:</strong> Shift + Mouse wheel or Shift + Arrow keys</li>
                        <li><strong>Pan:</strong> Middle-click drag or Ctrl + left-click drag</li>
                        <li><strong>Zoom in/out:</strong> Ctrl + Mouse wheel up/down</li>
                        <li><strong>Faster Scroll:</strong> Page Up/Down keys</li>
                        <li><strong>Jump to Edges:</strong> Home/End keys</li>
+                       <li><strong>Toggle Node:</strong> Double-click on node</li>
+                       <li><strong>Debug Node:</strong> Ctrl + click on node</li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
- Add selected node state management to controller
- Implement visual selection indicator with dashed rectangle
- Add click handlers for node selection (single-click to select)
- Implement arrow key navigation based on physical node positions
- Update help documentation with new navigation controls
- Preserve existing functionality (double-click toggle, ctrl+click debug)

🤖 Generated with [Claude Code](https://claude.ai/code)