### PR TITLE
feat: add expand-on-key functionality for directional layouts

### DIFF
--- a/src/layout/classic-mindmap-layout.js
+++ b/src/layout/classic-mindmap-layout.js
@@ -103,6 +103,30 @@ class ClassicMindmapLayout extends ColumnBasedLayout {
   }
 
   /**
+   * Check if the key press should expand a collapsed node instead of navigating
+   * @param {string} key - The arrow key pressed
+   * @param {Object} currentNode - The currently selected node
+   * @param {Object} styleManager - The style manager for getting node styles
+   * @returns {boolean} True if the node should be expanded, false otherwise
+   */
+  shouldExpandOnKey(key, currentNode, styleManager) {
+    console.log(`ClassicMindmapLayout.shouldExpandOnKey: Checking key "${key}" for node "${currentNode.text}"`);
+    
+    // Only expand if node is collapsed and has children
+    if (!currentNode.collapsed || !currentNode.children || currentNode.children.length === 0) {
+      console.log(`ClassicMindmapLayout.shouldExpandOnKey: Node not collapsed or has no children, returning false`);
+      return false;
+    }
+    
+    // In classic layout, children can be on both left and right sides
+    // So both left and right arrows should expand collapsed nodes
+    const shouldExpand = key === 'ArrowLeft' || key === 'ArrowRight';
+    console.log(`ClassicMindmapLayout.shouldExpandOnKey: shouldExpand=${shouldExpand}`);
+    
+    return shouldExpand;
+  }
+
+  /**
    * Get column positioning configuration for ClassicMindmapLayout
    * @param {Node} node - The parent node
    * @param {Object} nodeSize - The parent node size

--- a/src/layout/horizontal-layout.js
+++ b/src/layout/horizontal-layout.js
@@ -247,6 +247,33 @@ class HorizontalLayout extends Layout {
   }
 
   /**
+   * Check if the key press should expand a collapsed node instead of navigating
+   * @param {string} key - The arrow key pressed
+   * @param {Object} currentNode - The currently selected node
+   * @param {Object} styleManager - The style manager for getting node styles
+   * @returns {boolean} True if the node should be expanded, false otherwise
+   */
+  shouldExpandOnKey(key, currentNode, styleManager) {
+    console.log(`HorizontalLayout.shouldExpandOnKey: Checking key "${key}" for node "${currentNode.text}"`);
+    
+    // Only expand if node is collapsed and has children
+    if (!currentNode.collapsed || !currentNode.children || currentNode.children.length === 0) {
+      console.log(`HorizontalLayout.shouldExpandOnKey: Node not collapsed or has no children, returning false`);
+      return false;
+    }
+    
+    // Determine layout direction
+    const direction = styleManager.getEffectiveValue(currentNode, 'direction') || this.direction;
+    const isRightLayout = direction === 'right' || direction === null;
+    const childKey = isRightLayout ? 'ArrowRight' : 'ArrowLeft';
+    
+    const shouldExpand = key === childKey;
+    console.log(`HorizontalLayout.shouldExpandOnKey: direction="${direction}", childKey="${childKey}", shouldExpand=${shouldExpand}`);
+    
+    return shouldExpand;
+  }
+
+  /**
    * Find the child node closest vertically to the current node in the specified direction
    * @param {Object} currentNode - The parent node
    * @param {string} direction - 'right' or 'left'

--- a/src/layout/layout.js
+++ b/src/layout/layout.js
@@ -24,6 +24,20 @@ class Layout {
   }
 
   /**
+   * Check if the key press should expand a collapsed node instead of navigating
+   * @param {string} key - The arrow key pressed ('ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight')
+   * @param {Object} currentNode - The currently selected node
+   * @param {Object} styleManager - The style manager for getting node styles
+   * @returns {boolean} True if the node should be expanded, false otherwise
+   */
+  shouldExpandOnKey(key, currentNode, styleManager) {
+    console.log(`Layout.shouldExpandOnKey: Default implementation for ${this.constructor.name}`);
+    // Default implementation: no expansion behavior
+    // Subclasses should override this method to provide layout-specific expansion
+    return false;
+  }
+
+  /**
    * Helper: Find sibling node
    * @param {Object} node - The current node
    * @param {string} direction - 'prev' or 'next'

--- a/src/layout/outline-layout.js
+++ b/src/layout/outline-layout.js
@@ -362,6 +362,30 @@ class OutlineLayout extends Layout {
   }
 
   /**
+   * Check if the key press should expand a collapsed node instead of navigating
+   * @param {string} key - The arrow key pressed
+   * @param {Object} currentNode - The currently selected node
+   * @param {Object} styleManager - The style manager for getting node styles
+   * @returns {boolean} True if the node should be expanded, false otherwise
+   */
+  shouldExpandOnKey(key, currentNode, styleManager) {
+    console.log(`OutlineLayout.shouldExpandOnKey: Checking key "${key}" for node "${currentNode.text}"`);
+    
+    // Only expand if node is collapsed and has children
+    if (!currentNode.collapsed || !currentNode.children || currentNode.children.length === 0) {
+      console.log(`OutlineLayout.shouldExpandOnKey: Node not collapsed or has no children, returning false`);
+      return false;
+    }
+    
+    // In outline layout, children are positioned below the parent
+    // So down arrow should expand collapsed nodes
+    const shouldExpand = key === 'ArrowDown';
+    console.log(`OutlineLayout.shouldExpandOnKey: shouldExpand=${shouldExpand}`);
+    
+    return shouldExpand;
+  }
+
+  /**
    * Apply outline layout to a node and its children
    * @param {Node} node - The node to layout
    * @param {number} x - The x coordinate

--- a/src/layout/taproot-layout.js
+++ b/src/layout/taproot-layout.js
@@ -97,6 +97,30 @@ class TapRootLayout extends ColumnBasedLayout {
   }
 
   /**
+   * Check if the key press should expand a collapsed node instead of navigating
+   * @param {string} key - The arrow key pressed
+   * @param {Object} currentNode - The currently selected node
+   * @param {Object} styleManager - The style manager for getting node styles
+   * @returns {boolean} True if the node should be expanded, false otherwise
+   */
+  shouldExpandOnKey(key, currentNode, styleManager) {
+    console.log(`TapRootLayout.shouldExpandOnKey: Checking key "${key}" for node "${currentNode.text}"`);
+    
+    // Only expand if node is collapsed and has children
+    if (!currentNode.collapsed || !currentNode.children || currentNode.children.length === 0) {
+      console.log(`TapRootLayout.shouldExpandOnKey: Node not collapsed or has no children, returning false`);
+      return false;
+    }
+    
+    // In taproot layout, children are arranged below the parent
+    // So down arrow should expand collapsed nodes
+    const shouldExpand = key === 'ArrowDown';
+    console.log(`TapRootLayout.shouldExpandOnKey: shouldExpand=${shouldExpand}`);
+    
+    return shouldExpand;
+  }
+
+  /**
    * Find nodes in the same column (for taproot layout)
    * @param {Object} node - The current node
    * @returns {Array} Array of nodes in the same column

--- a/src/layout/vertical-layout.js
+++ b/src/layout/vertical-layout.js
@@ -283,6 +283,33 @@ class VerticalLayout extends Layout {
   }
 
   /**
+   * Check if the key press should expand a collapsed node instead of navigating
+   * @param {string} key - The arrow key pressed
+   * @param {Object} currentNode - The currently selected node
+   * @param {Object} styleManager - The style manager for getting node styles
+   * @returns {boolean} True if the node should be expanded, false otherwise
+   */
+  shouldExpandOnKey(key, currentNode, styleManager) {
+    console.log(`VerticalLayout.shouldExpandOnKey: Checking key "${key}" for node "${currentNode.text}"`);
+    
+    // Only expand if node is collapsed and has children
+    if (!currentNode.collapsed || !currentNode.children || currentNode.children.length === 0) {
+      console.log(`VerticalLayout.shouldExpandOnKey: Node not collapsed or has no children, returning false`);
+      return false;
+    }
+    
+    // Determine layout direction
+    const direction = styleManager.getEffectiveValue(currentNode, 'direction') || this.direction;
+    const isDownLayout = direction === 'down' || direction === null;
+    const childKey = isDownLayout ? 'ArrowDown' : 'ArrowUp';
+    
+    const shouldExpand = key === childKey;
+    console.log(`VerticalLayout.shouldExpandOnKey: direction="${direction}", childKey="${childKey}", shouldExpand=${shouldExpand}`);
+    
+    return shouldExpand;
+  }
+
+  /**
    * Apply vertical layout to a node and its children
    * @param {Node} node - The node to layout
    * @param {number} x - The x coordinate


### PR DESCRIPTION
## Feature Overview
Collapsed nodes now expand when pressing the arrow key in the layout's primary direction, providing intuitive keyboard-based node expansion.

## Layout-Specific Behavior
- **Horizontal-right**: Right arrow (→) expands collapsed nodes
- **Horizontal-left**: Left arrow (←) expands collapsed nodes
- **Vertical-down**: Down arrow (↓) expands collapsed nodes
- **Vertical-up**: Up arrow (↑) expands collapsed nodes
- **Taproot**: Down arrow (↓) expands collapsed nodes
- **Classic**: Both left (←) and right (→) arrows expand collapsed nodes
- **Outline**: Down arrow (↓) expands collapsed nodes

## Implementation
- Add shouldExpandOnKey() method to base Layout class and all layout implementations
- Add expandNode() method to MindmapController for node expansion logic
- Modify handleArrowKeyNavigation() to check for expansion before navigation
- Layout-aware expansion logic respects each layout's directional flow

## User Experience
- Intuitive: pressing layout direction naturally reveals children
- Backward compatible: only affects collapsed nodes with children
- Discoverable: users naturally try the layout direction to see children
- Consistent: works across all layout types

🤖 Generated with [Claude Code](https://claude.ai/code)